### PR TITLE
【Flutter最終課題】TagDetailListPage・記事をタップして記事ページを表示

### DIFF
--- a/mobile_qiita_app/lib/pages/tag_detail_list_page.dart
+++ b/mobile_qiita_app/lib/pages/tag_detail_list_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:mobile_qiita_app/constants.dart';
 import 'package:mobile_qiita_app/models/article.dart';
 import 'package:mobile_qiita_app/models/tag.dart';
+import 'package:mobile_qiita_app/pages/qiita_article_page.dart';
 import 'package:mobile_qiita_app/services/client.dart';
 import 'package:mobile_qiita_app/views/error_views.dart';
 
@@ -31,7 +32,7 @@ class _TagDetailListPageState extends State<TagDetailListPage> {
 
     return ListTile(
       onTap: () {
-        // TODO: 記事をタップして記事ページを表示
+        _showArticle(article);
       },
       leading: CircleAvatar(
         radius: 25,
@@ -71,6 +72,26 @@ class _TagDetailListPageState extends State<TagDetailListPage> {
             return _articleWidget(articles[index]);
           },
         ),
+      ),
+    );
+  }
+
+  // 記事項目タップで13-Qiita Article Pageへ遷移する
+  void _showArticle(Article article) {
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      shape: RoundedRectangleBorder(
+        borderRadius: const BorderRadius.vertical(top: Radius.circular(25.0)),
+      ),
+      builder: (BuildContext context) => DraggableScrollableSheet(
+        expand: false,
+        maxChildSize: 0.95,
+        minChildSize: 0.5,
+        initialChildSize: 0.95,
+        builder: (context, scrollController) {
+          return QiitaArticlePage(article: article);
+        },
       ),
     );
   }


### PR DESCRIPTION
## 概要
お世話になっております。
TagDetailListPageで記事をタップして記事ページを表示する実装をしました。
レビューよろしくお願いします。
<br>

## 新しく実装した内容
### 1. WebViewで記事ページを表示
WebViewでスクロール可能な記事を表示する実装をしました。
該当ファイル : lib/pages/tad_detail_list_page.dart
参考：lib/pages/feed_page.dart

<br>

## 今後の実装予定
 - TagDetailListPageのページネーション

<br>

## 実装後のUI

<video src="https://user-images.githubusercontent.com/82624334/150274421-ab6b6d15-0543-40cd-866b-ce0ba136ddf3.mp4"  width="40" height="80" autoplay muted><\video>

<br>
