### PR TITLE
【Flutter最終課題】TopPage・アクセストークン発行のスコープの修正

### DIFF
--- a/mobile_qiita_app/lib/common/constants.dart
+++ b/mobile_qiita_app/lib/common/constants.dart
@@ -17,7 +17,7 @@ class Constants {
 
   static final postedDateFormat = DateFormat('yyyy-MM-dd');
 
-  static const String scopeOfQiitaAuthorization = 'qiita_read';
+  static const String scopeOfQiitaAuthorization = 'read_qiita';
   static const String accessTokenEndPoint =
       'https://qiita.com/settings/applications?code';
 }


### PR DESCRIPTION
## 概要
お忙しいところ失礼します。
アクセストークン発行のスコープが"qiita_read"という誤った形式になっていたため、"read_qiita"に修正しました。
たった1行の修正ですが、この1行のミスのせいで今後の実装が全くできなくなってしまうのでプルリクを提出させていただきました。
問題なければマージよろしくお願いします。
<br>

## 修正した内容
"qiita_read"を"read_qiita"に変更 b9ea5e69cb72ee9c1af4eba51dc2b0a5f064d957
該当ファイル : mobile_qiita_app/lib/common/constants.dart
参考：https://community.4nonome.com/@yo/107766848418497869
<br>

## 今後の実装予定
 - My Pageの実装

<br>

## UIの比較
左が修正前、右が修正後です。
<img src="https://user-images.githubusercontent.com/82624334/153179779-63947e1a-a2b2-46ca-a25b-b86738f98893.png" width=30%> <img src="https://user-images.githubusercontent.com/82624334/153179773-462f595c-594d-49f2-b81f-1b35cccd1d99.png" width=30%>


<br>
