### PR TITLE
【Flutter最終課題】画面遷移をpushメソッドからpushAndRemoveUntilメソッドに変更

### DIFF
--- a/mobile_qiita_app/lib/pages/setting_page.dart
+++ b/mobile_qiita_app/lib/pages/setting_page.dart
@@ -58,10 +58,11 @@ class _SettingPageState extends State<SettingPage> {
     await _deleteUserInfoFromStorage();
     Variables.isAuthenticated = false;
 
-    Navigator.of(context, rootNavigator: true).push(
+    Navigator.of(context, rootNavigator: true).pushAndRemoveUntil(
       MaterialPageRoute(
         builder: (context) => TopPage(),
       ),
+      (_) => false,
     );
   }
 

--- a/mobile_qiita_app/lib/pages/top_page.dart
+++ b/mobile_qiita_app/lib/pages/top_page.dart
@@ -23,11 +23,11 @@ class _TopPageState extends State<TopPage> {
     _isLoading = true;
     await QiitaClient.fetchAccessToken(widget.redirectUrl.toString());
     _isLoading = false;
-    Navigator.push(
-      context,
+    Navigator.of(context).pushAndRemoveUntil(
       MaterialPageRoute(
         builder: (context) => BottomNavigation(),
       ),
+      (_) => false,
     );
   }
 


### PR DESCRIPTION
<!-- 【Flutter最終課題】 -->
## 概要
お忙しいところ失礼します。
前の画面に戻るのを防ぐため、画面遷移をpushメソッドからpushAndRemoveUntilメソッドに変更しました。
レビューよろしくお願いします。
6938428e5ce8dc734d8901a3e16b694c27bc36cf
<br>

## Client IDとClient Secret
Client IDとClient Secretが書かれているファイル（qiita_auth_key.dart）は [こちら](https://drive.google.com/file/d/1yv6hG-jKviItMLHo928iLZKPUp1HoijL/view?usp=sharing)からダウンロードしてください。
ダウンロードしたファイルはmobile_qiita_app/lib/に格納してください。
よろしくお願いします。
<br>

## 実装後のUI

https://user-images.githubusercontent.com/82624334/159873091-b7d17220-259b-47be-9ef6-56046e536bdf.mp4

https://user-images.githubusercontent.com/82624334/159873107-93e6a92a-28e3-4619-89ce-828e7e8575ed.mp4

<br>

## 参考
https://qiita.com/granoeste/items/19c119ffc36a016e6223